### PR TITLE
Replace deprecated `File.exists?` with `File.exist?`

### DIFF
--- a/lib/rails_exception_handler/handler.rb
+++ b/lib/rails_exception_handler/handler.rb
@@ -59,7 +59,7 @@ class RailsExceptionHandler::Handler
   end
 
   def override_body_with_file_if_exists(response, file)
-    return response unless File.exists?(file)
+    return response unless File.exist?(file)
 
     if defined? response[2].body=()
       response[2].body = File.read(file)

--- a/spec/dummy_30/config/boot.rb
+++ b/spec/dummy_30/config/boot.rb
@@ -3,4 +3,4 @@ require 'rubygems'
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/spec/dummy_32/config/boot.rb
+++ b/spec/dummy_32/config/boot.rb
@@ -3,4 +3,4 @@ require 'rubygems'
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/spec/dummy_40/config/boot.rb
+++ b/spec/dummy_40/config/boot.rb
@@ -1,4 +1,4 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/spec/test_macros.rb
+++ b/spec/test_macros.rb
@@ -52,9 +52,9 @@ module TestMacros
 
   def delete_static_error_pages
     path = Rails.root + 'public/404.html'
-    File.delete(path) if File.exists?(path)
+    File.delete(path) if File.exist?(path)
     path = Rails.root + 'public/500.html'
-    File.delete(path) if File.exists?(path)
+    File.delete(path) if File.exist?(path)
   end
 
   def reset_configuration


### PR DESCRIPTION
The functions in question were marked as obsolete in Ruby 2.1 and subsequently eliminated in version 3.2. However, the File.exist? function, which provides identical functionality, has been accessible since Ruby 1.8. Therefore, backward compatibility should not pose any issues in this context