### PR TITLE
Refactor the structure to use modules instead of classes

### DIFF
--- a/app/controllers/error_response_controller.rb
+++ b/app/controllers/error_response_controller.rb
@@ -1,5 +1,5 @@
-if(RailsExceptionHandler.configuration.activate?)
-  class ErrorResponseController < ApplicationController
+class ErrorResponseController < ApplicationController
+  if(RailsExceptionHandler.configuration.activate?)
 
     if Rails::VERSION::MAJOR > 3
       skip_before_action :verify_authenticity_token

--- a/lib/rails_exception_handler.rb
+++ b/lib/rails_exception_handler.rb
@@ -1,3 +1,13 @@
+require 'net/http'
+
+require 'rails_exception_handler/configuration'
+require 'rails_exception_handler/handler'
+require 'rails_exception_handler/parser'
+require 'rails_exception_handler/storage'
+require 'rails_exception_handler/engine'
+require 'rails_exception_handler/catcher'
+require 'rails_exception_handler/fake_session'
+
 class RailsExceptionHandler
 
   def initialize(app)
@@ -40,11 +50,3 @@ end
 class RailsExceptionHandler::Mongoid
 end
 
-require 'rails_exception_handler/configuration.rb'
-require 'rails_exception_handler/handler.rb'
-require 'rails_exception_handler/parser.rb'
-require 'rails_exception_handler/storage.rb'
-require 'rails_exception_handler/engine.rb'
-require 'rails_exception_handler/catcher.rb'
-require 'rails_exception_handler/fake_session.rb'
-require 'net/http'

--- a/lib/rails_exception_handler.rb
+++ b/lib/rails_exception_handler.rb
@@ -30,8 +30,8 @@ module RailsExceptionHandler
     yield configuration
     return unless configuration.activate?
 
-    unless Rails.configuration.middleware.class == ActionDispatch::MiddlewareStack && Rails.configuration.middleware.include?(RailsExceptionHandler)
-      Rails.configuration.middleware.use(RailsExceptionHandler::Middleware)
+    unless Rails.configuration.middleware.class == ActionDispatch::MiddlewareStack && Rails.configuration.middleware.include?(Middleware)
+      Rails.configuration.middleware.use(Middleware)
     end
 
 

--- a/lib/rails_exception_handler/catcher.rb
+++ b/lib/rails_exception_handler/catcher.rb
@@ -1,4 +1,4 @@
-class RailsExceptionHandler
+module RailsExceptionHandler
 
   def self.catch(&block)
     begin

--- a/lib/rails_exception_handler/configuration.rb
+++ b/lib/rails_exception_handler/configuration.rb
@@ -1,57 +1,59 @@
-class RailsExceptionHandler::Configuration
-  attr_accessor :storage_strategies, :environments, :filters, :responses, :response_mapping, :fallback_layout, :store_user_info, :env_info_block, :global_info_block, :exception_info_block, :request_info_block, :mongoid_store_in, :active_record_store_in
+module RailsExceptionHandler
+  class Configuration
+    attr_accessor :storage_strategies, :environments, :filters, :responses, :response_mapping, :fallback_layout, :store_user_info, :env_info_block, :global_info_block, :exception_info_block, :request_info_block, :mongoid_store_in, :active_record_store_in
 
-  def initialize
-    @active_record_store_in = {
-      database: 'exception_database',
-      record_table: 'error_messages'
-    }
-    @environments = [:production]
-    @storage_strategies = []
-    @filters = []
-    @store_user_info = false
-    @fallback_layout = 'application'
-    @response_mapping = {}
-    @responses = {}
-  end
+    def initialize
+      @active_record_store_in = {
+        database: 'exception_database',
+        record_table: 'error_messages'
+      }
+      @environments = [:production]
+      @storage_strategies = []
+      @filters = []
+      @store_user_info = false
+      @fallback_layout = 'application'
+      @response_mapping = {}
+      @responses = {}
+    end
 
-  def active_record?
-    @storage_strategies.include?(:active_record)
-  end
+    def active_record?
+      @storage_strategies.include?(:active_record)
+    end
 
-  def mongoid?
-    @storage_strategies.include?(:mongoid)
-  end
+    def mongoid?
+      @storage_strategies.include?(:mongoid)
+    end
 
-  def email?
-    @storage_strategies.collect{|s| s.is_a?(Hash) ? s.keys : s}.flatten.include?(:email)
-  end
+    def email?
+      @storage_strategies.collect{|s| s.is_a?(Hash) ? s.keys : s}.flatten.include?(:email)
+    end
 
-  def activate?
-    environments.include?(Rails.env.to_sym)
-  end
+    def activate?
+      environments.include?(Rails.env.to_sym)
+    end
 
-  def after_initialize(&block)
-    @callback = block
-  end
+    def after_initialize(&block)
+      @callback = block
+    end
 
-  def run_callback
-    @callback.call if(@callback)
-  end
+    def run_callback
+      @callback.call if(@callback)
+    end
 
-  def store_environment_info(&block)
-    @env_info_block = block
-  end
+    def store_environment_info(&block)
+      @env_info_block = block
+    end
 
-  def store_global_info(&block)
-    @global_info_block = block
-  end
+    def store_global_info(&block)
+      @global_info_block = block
+    end
 
-  def store_exception_info(&block)
-    @exception_info_block = block
-  end
+    def store_exception_info(&block)
+      @exception_info_block = block
+    end
 
-  def store_request_info(&block)
-    @request_info_block = block
+    def store_request_info(&block)
+      @request_info_block = block
+    end
   end
 end

--- a/lib/rails_exception_handler/engine.rb
+++ b/lib/rails_exception_handler/engine.rb
@@ -1,4 +1,4 @@
-class RailsExceptionHandler
+module RailsExceptionHandler
   class Engine < Rails::Engine
   end
 end


### PR DESCRIPTION
This PR fixes two bugs I encountered while trying to build Docker images with Rails.

### 3. Replace class with module

Currently when I create a docker image of the application it displays the error below:

```txt
Puma starting in single mode...
* Puma version: 7.0.4 ("Romantic Warrior")
* Ruby version: ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
*  Min threads: 3
*  Max threads: 3
*  Environment: production
*          PID: 1
! Unable to load application: LoadError: cannot load such file -- /usr/local/bundle/ruby/3.3.0/gems/rails_exception_handler-2.4.10/lib/rails_exception_handler/configuration.rb
bundler: failed to load command: puma (/usr/local/bundle/ruby/3.3.0/bin/puma)
/usr/local/lib/ruby/3.3.0/bundled_gems.rb:74:in `require': cannot load such file -- /usr/local/bundle/ruby/3.3.0/gems/rails_exception_handler-2.4.10/lib/rails_exception_handler/configuration.rb (LoadError)

```

To fix this, I moved the imports to the top of the file and made RailsExceptionHandler a module. The other child classes were adjusted accordingly.

### 2. Warning when running `Zeitwerk`

When running `rails zeitwerk:check` in my application, I get the following warning:

```txt
Hold on, I am eager loading the application.
expected file .../ruby/3.3.0/lib/ruby/gems/3.3.0/gems/rails_exception_handler-2.4.10/app/controllers/error_response_controller.rb to define constant ErrorResponseController, but didn't
```

To fix this I changed the `ErrorResponseController` to always set the class, but the content is only set if `RailsExceptionHandler.configuration.activate?`

**Notes:**

I'm using it in my application without any errors so far. I haven't been able to test it on all Rails versions.
